### PR TITLE
Preserve WAV sample rate and number of channels

### DIFF
--- a/record_handle.py
+++ b/record_handle.py
@@ -51,10 +51,11 @@ def choose_rtx_output():
     return int(microphone_choice)
 
 
-def record(length=10, user_output_name="file", mic_input='',bitrate_input=48000):
+def record(length=10, user_output_name="file", mic_input='',
+           sample_rate=48000, channels=2):
     FORMAT = pyaudio.paInt16
-    CHANNELS = 2
-    RATE = bitrate_input
+    CHANNELS = channels
+    RATE = sample_rate
     CHUNK = 1024
     RECORD_SECONDS = length
 
@@ -71,7 +72,7 @@ def record(length=10, user_output_name="file", mic_input='',bitrate_input=48000)
         format=FORMAT,
         channels=CHANNELS,
         input_device_index=mic_input,
-        rate=RATE,
+        rate=sample_rate,
         input=True,
         frames_per_buffer=CHUNK,
     )
@@ -90,9 +91,9 @@ def record(length=10, user_output_name="file", mic_input='',bitrate_input=48000)
     pyaudio_inst.terminate()
 
     waveFile = wave.open(WAVE_OUTPUT_FILENAME, "wb")
-    waveFile.setnchannels(CHANNELS)
+    waveFile.setnchannels(channels)
     waveFile.setsampwidth(pyaudio_inst.get_sample_size(FORMAT))
-    waveFile.setframerate(RATE)
+    waveFile.setframerate(sample_rate)
     waveFile.writeframes(b"".join(frames))
     waveFile.close()
     print("Complete!\n")

--- a/rtx-core.py
+++ b/rtx-core.py
@@ -5,6 +5,7 @@ import time
 
 from mutagen.mp3 import MP3
 from mutagen.flac import FLAC
+from mutagen.wave import WAVE
 
 from input_handle import *
 from record_handle import *
@@ -34,8 +35,8 @@ def main(argv):
         codec = "MP3"
         convert = True
     elif "wav" in input_file_extension.lower():
-        codec = "MP3"
-        convert = True
+        codec = "WAVE"
+        convert = False
 
     # Convert the input file to MP3 if it is not already
     if convert == True:
@@ -64,15 +65,19 @@ def main(argv):
         input_track = MP3(input_song_path)
     elif codec == "FLAC":
         input_track = FLAC(input_song_path)
+    elif codec == "WAVE":
+        input_track = WAVE(input_song_path)
     
     length_of_input_song = int(input_track.info.length)
     hours, mins, seconds = convertTime(length_of_input_song)
-    bitrate_of_input_song = int(input_track.info.sample_rate)
+    bitrate_of_input_song = int(input_track.info.bitrate)
     sample_rate_input_song = int(input_track.info.sample_rate)
+    channels = int(input_track.info.channels)
 
     # Print some info about the song to the console
     print("\nNow Processing: " + input_song_path + "\n")
-    print("SampleRat: " + str(bitrate_of_input_song))
+    print("SampleRate: " + str(sample_rate_input_song))
+    print("Bitrate: " + str(bitrate_of_input_song))
     print('Duration: %s:%s:%s' % (hours, mins, seconds))
     print("Playbacktime is in Realtime, this tool tunnels the audio to the RTX Voice Input")
     print("Endtime: " + add_time(hours, mins, seconds))
@@ -82,7 +87,8 @@ def main(argv):
     length_of_input_song+addTimepaddding,
     export_song_path,
     mic_input,
-    bitrate_of_input_song
+    sample_rate_input_song,
+    channels=channels
     )
     mixer.music.stop()  # Stop it
     mixer.quit()  # Quit it


### PR DESCRIPTION
Allows for running through large (~GB), mono, 16kHz wavs that would exceed file size limit otherwise; also the conversion to mp3 was lossy, not optimal.